### PR TITLE
Validate client_id in non-PKCE flow and add PKCE test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,15 +248,13 @@ app.post('/token', async (c) => {
 				400,
 			);
 		}
-		// For non-PKCE flow, validate client_secret
+		// For non-PKCE flow, validate client_id and client_secret
+		if (body.client_id !== c.env.OIDC_CLIENT_ID) {
+			return c.json<TokenErrorResponse>({ error: 'invalid_client', error_description: 'invalid client_id' }, 401);
+		}
 		if (body.client_secret !== c.env.OIDC_CLIENT_SECRET) {
 			return c.json<TokenErrorResponse>({ error: 'invalid_client', error_description: 'client_secret is required or invalid' }, 401);
 		}
-	}
-
-	// Validate client_id
-	if (body.client_id !== c.env.OIDC_CLIENT_ID) {
-		return c.json<TokenErrorResponse>({ error: 'invalid_client', error_description: 'invalid client_id' }, 401);
 	}
 
 	// Fetch user information from Discord

--- a/test/token.spec.ts
+++ b/test/token.spec.ts
@@ -115,6 +115,70 @@ describe('/token endpoint', () => {
 		expect(idTokenPayload.sub).toBe('discord_user_id');
 	});
 
+	it('should successfully exchange authorization code for tokens with PKCE without client_id', async () => {
+		const discordAccessToken = 'mock_discord_access_token';
+		const nonce = 'test_nonce';
+		const scope = 'openid profile email';
+		const codeVerifier = 'test_code_verifier_123456789012345678901234567890';
+		const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+		// Create a mock OIDC authorization code (JWE)
+		const codePrivateKey = JSON.parse(MOCK_CODE_PRIVATE_KEY);
+		const codePublicKey = await importJWK({ ...codePrivateKey, d: undefined });
+		const oidcCode = await new EncryptJWT({
+			discord_access_token: discordAccessToken,
+			nonce: nonce,
+			scope: scope,
+			code_challenge: codeChallenge,
+			code_challenge_method: 'S256',
+		})
+			.setProtectedHeader({ alg: 'ECDH-ES', enc: 'A256GCM' })
+			.setIssuedAt()
+			.setIssuer('http://localhost')
+			.setAudience(MOCK_OIDC_CLIENT_ID)
+			.setExpirationTime('5m')
+			.encrypt(codePublicKey);
+
+		const formData = new URLSearchParams({
+			grant_type: 'authorization_code',
+			// client_id is omitted for PKCE flow
+			code: oidcCode,
+			code_verifier: codeVerifier,
+		});
+
+		const response = await SELF.fetch('http://localhost/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: formData.toString(),
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+
+		expect(body.access_token).toBeDefined();
+		expect(body.token_type).toBe('Bearer');
+		expect(body.expires_in).toBe(3600);
+		expect(body.scope).toBe(scope);
+		expect(body.id_token).toBeDefined();
+
+		// Verify id_token
+		const privateJwk = JSON.parse(MOCK_JWT_PRIVATE_KEY);
+		const publicKey = await importJWK({ ...privateJwk, d: undefined }, 'ES256');
+		const { payload: idTokenPayload } = await jwtVerify(body.id_token, publicKey, {
+			issuer: 'http://localhost',
+			audience: MOCK_OIDC_CLIENT_ID,
+		});
+
+		expect(idTokenPayload.name).toBe('testuser');
+		expect(idTokenPayload.picture).toBe('https://cdn.discordapp.com/avatars/discord_user_id/testavatar.png');
+		expect(idTokenPayload.email).toBe('test@example.com');
+		expect(idTokenPayload.email_verified).toBe(true);
+		expect(idTokenPayload.nonce).toBe(nonce);
+		expect(idTokenPayload.iss).toBe('http://localhost');
+		expect(idTokenPayload.aud).toBe(MOCK_OIDC_CLIENT_ID);
+		expect(idTokenPayload.sub).toBe('discord_user_id');
+	});
+
 	it('should return 400 for invalid grant_type', async () => {
 		const formData = new URLSearchParams({
 			grant_type: 'invalid_grant',


### PR DESCRIPTION
This pull request improves the `/token` endpoint's handling of OAuth 2.0 PKCE and non-PKCE flows, ensuring correct validation of `client_id` and `client_secret`, and adds comprehensive test coverage for PKCE scenarios. The main changes are grouped below by theme:

**Endpoint validation improvements:**

* Updated the `/token` endpoint in `src/index.ts` to validate both `client_id` and `client_secret` for non-PKCE flows, ensuring that requests without PKCE require both credentials. The validation for `client_id` was moved inside the non-PKCE conditional block for clarity and correctness.

**Test coverage enhancements:**

* Added a new test case to `test/token.spec.ts` that verifies successful token exchange using PKCE without providing `client_id`, confirming that the endpoint correctly supports PKCE flows as per the OAuth 2.0 specification. The test checks issuance and validity of tokens and the correctness of claims in the resulting `id_token`.Moved client_id validation into the non-PKCE flow in the /token endpoint to ensure correct handling. Added a test case to verify successful token exchange using PKCE without client_id.