### PR TITLE
Replace decodeBase64Url with decodeBase64

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
-import { decodeBase64Url } from 'hono/utils/encode';
+import { decodeBase64 } from 'hono/utils/encode';
 import { type JWK, type JWTPayload, SignJWT, importJWK } from 'jose';
 import { type CodePayload, decodeCode, decodeState, encodeCode, encodeState } from './coder.js';
 import { DiscordAPIError, exchangeCode, getDiscordUser, getDiscordUserRoles } from './discord.js';
@@ -145,7 +145,7 @@ app.get('/auth', async (c) => {
 			code_challenge_method: code_challenge_method || 'S256',
 			client_id: client_id,
 		},
-		decodeBase64Url(c.env.STATE_SECRET),
+		decodeBase64(c.env.STATE_SECRET),
 		new URL(c.req.url).origin,
 		c.env.DISCORD_CLIENT_ID,
 	);
@@ -169,7 +169,7 @@ app.get('/callback', async (c) => {
 	if (!state) throw new HTTPException(400, { message: 'state is required' });
 
 	// Verify the state (JWT)
-	const statePayload = await decodeState(state, decodeBase64Url(c.env.STATE_SECRET), issuer, c.env.DISCORD_CLIENT_ID);
+	const statePayload = await decodeState(state, decodeBase64(c.env.STATE_SECRET), issuer, c.env.DISCORD_CLIENT_ID);
 
 	// Exchange the Discord authorization code for an access token
 	let discordTokens;


### PR DESCRIPTION
This pull request updates the way the application decodes the `STATE_SECRET` environment variable by switching from `decodeBase64Url` to `decodeBase64`. This change ensures that the secret is decoded using standard Base64 encoding rather than the URL-safe variant, which may improve compatibility and correctness when handling secrets.

Authentication and state verification:

* Replaced `decodeBase64Url` with `decodeBase64` for decoding the `STATE_SECRET` in both the `/auth` and `/callback` routes, ensuring consistent and standard Base64 decoding for JWT state verification. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L3-R3) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L148-R148) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L172-R172)Swapped out usage of decodeBase64Url for decodeBase64 in state secret decoding to align with updated hono/utils/encode API.